### PR TITLE
Download of assets from private repos

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,6 @@ FROM alpine
 
 RUN apk add jq curl
 
-COPY entrypoint.sh /entrypoint.sh
-COPY gh-dl-release /gh-dl-release
+COPY entrypoint.sh gh-dl-release /
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM alpine
 
+RUN apk add jq curl
+
 COPY entrypoint.sh /entrypoint.sh
+COPY gh-dl-release /gh-dl-release
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 GitHub Action for downloading files from GitHub release.
 It can download the source zip archive and unzip it into a directory.
 It is also possible to download any other file of the release.
+This action can download from public and private repositories.
 
 ## Usage
 See [action.yml](action.yml) for comprehensive list of parameters.
@@ -24,7 +25,7 @@ jobs:
         file: OpenWhisk_CLI-0.10.0-incubating-all.tgz
 ```
 
-If your asset belongs to a private repository you need to define a `GITHUB_TOKEN` environment variable and define a `private: true` input parameters, like so:
+If your asset belongs to a private repository you need to pass a Github token with the `repo` permission, like so:
 
 ```yaml
 on: push
@@ -37,14 +38,13 @@ jobs:
     - name: Download CLI
       uses: Legion2/download-release-action@v2.0.0
       with:
-        repository: apache/openwhisk-cli
-        tag: '0.10.0-incubating'
+        repository: Legion2/private-repo
+        tag: '1.0.0'
         path: downloads
-        file: OpenWhisk_CLI-0.10.0-incubating-all.tgz
-        private: true
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        file: hello-world.sh
+        token: ${{ secrets.SECRET_NAME }}
 ```
+Most likely you can't use `${{ secrets.GITHUB_TOKEN }}` because it only allow access to the repo of the current workflow and not to other private repositories.s
 
 ## License
 The Dockerfile and associated scripts and documentation in this project are released under the [Apache-2.0 License](LICENSE).

--- a/README.md
+++ b/README.md
@@ -24,5 +24,27 @@ jobs:
         file: OpenWhisk_CLI-0.10.0-incubating-all.tgz
 ```
 
+If your asset belongs to a private repository you need to define a `GITHUB_TOKEN` environment variable and define a `private: true` input parameters, like so:
+
+```yaml
+on: push
+name: Main Workflow
+jobs:
+  build:
+    name: "Download release"
+    runs-on: ubuntu-latest
+    steps:
+    - name: Download CLI
+      uses: Legion2/download-release-action@v2.0.0
+      with:
+        repository: apache/openwhisk-cli
+        tag: '0.10.0-incubating'
+        path: downloads
+        file: OpenWhisk_CLI-0.10.0-incubating-all.tgz
+        private: true
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
 ## License
 The Dockerfile and associated scripts and documentation in this project are released under the [Apache-2.0 License](LICENSE).

--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,9 @@ inputs:
   path:
     description: 'download directory'
     default: './'
+  private:
+    description: 'Private repo flag'
+    default: false
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/action.yml
+++ b/action.yml
@@ -11,14 +11,16 @@ inputs:
     description: 'The version tag of the release'
     required: true
   file:
-    description: 'The file which should be downloaded'
+    description: |
+      The file which should be downloaded.
+      If not specified download the source code. 
     required: false
   path:
     description: 'download directory'
     default: './'
-  private:
-    description: 'Private repo flag'
-    default: false
+  token:
+    description: 'Github token to access private repositories'
+    required: false
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,6 +5,7 @@ RELEASE_REPOSITORY="$INPUT_REPOSITORY"
 RELEASE_TAG="$INPUT_TAG"
 TARGET_PATH="$INPUT_PATH"
 ASSET="$INPUT_FILE"
+PRIVATE="$INPUT_PRIVATE"
 
 if [ -z "$TARGET_PATH" ]; then
     TARGET_PATH="${GITHUB_WORKSPACE}"
@@ -13,10 +14,23 @@ fi
 mkdir -p "$TARGET_PATH"
 cd "$TARGET_PATH"
 
-if [ -n "$ASSET" ]; then
-    wget https://github.com/${RELEASE_REPOSITORY}/releases/download/${RELEASE_TAG}/${ASSET}
+if [ "$PRIVATE" == "true" ]; then
+    if [ -z "$GITHUB_TOKEN" ]; then
+        echo "GITHUB_TOKEN is not set. Quitting."
+        exit 1
+    fi
+    if [ -z "$ASSET" ]; then
+        echo "input file undefined. Quitting."
+        exit 1
+    fi
+
+    /gh-dl-release $GITHUB_TOKEN $RELEASE_REPOSITORY $ASSET $RELEASE_TAG $TARGET_PATH
 else
-    wget -O download.tmp https://github.com/${RELEASE_REPOSITORY}/archive/${RELEASE_TAG}.zip
-    unzip download.tmp
-    rm download.tmp
+    if [ -n "$ASSET" ]; then
+        wget https://github.com/${RELEASE_REPOSITORY}/releases/download/${RELEASE_TAG}/${ASSET}
+    else
+        wget -O download.tmp https://github.com/${RELEASE_REPOSITORY}/archive/${RELEASE_TAG}.zip
+        unzip download.tmp
+        rm download.tmp
+    fi
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,7 +5,7 @@ RELEASE_REPOSITORY="$INPUT_REPOSITORY"
 RELEASE_TAG="$INPUT_TAG"
 TARGET_PATH="$INPUT_PATH"
 ASSET="$INPUT_FILE"
-PRIVATE="$INPUT_PRIVATE"
+TOKEN="$INPUT_TOKEN"
 
 if [ -z "$TARGET_PATH" ]; then
     TARGET_PATH="${GITHUB_WORKSPACE}"
@@ -14,23 +14,11 @@ fi
 mkdir -p "$TARGET_PATH"
 cd "$TARGET_PATH"
 
-if [ "$PRIVATE" == "true" ]; then
-    if [ -z "$GITHUB_TOKEN" ]; then
-        echo "GITHUB_TOKEN is not set. Quitting."
-        exit 1
-    fi
-    if [ -z "$ASSET" ]; then
-        echo "input file undefined. Quitting."
-        exit 1
-    fi
-
-    /gh-dl-release $GITHUB_TOKEN $RELEASE_REPOSITORY $ASSET $RELEASE_TAG $TARGET_PATH
+if [ -n "$ASSET" ]; then
+    /gh-dl-release "$RELEASE_REPOSITORY" "$RELEASE_TAG" "$ASSET" $TOKEN
 else
-    if [ -n "$ASSET" ]; then
-        wget https://github.com/${RELEASE_REPOSITORY}/releases/download/${RELEASE_TAG}/${ASSET}
-    else
-        wget -O download.tmp https://github.com/${RELEASE_REPOSITORY}/archive/${RELEASE_TAG}.zip
-        unzip download.tmp
-        rm download.tmp
-    fi
+    wget -O download.tmp https://github.com/${RELEASE_REPOSITORY}/archive/${RELEASE_TAG}.zip
+    unzip download.tmp
+    rm download.tmp
 fi
+

--- a/gh-dl-release
+++ b/gh-dl-release
@@ -47,7 +47,7 @@ fi
 
 PARSER=".assets | map(select(.name == \"$FILE\"))[0].id"
 
-ASSET_ID=`gh_curl https://$GITHUB_API_ENDPOINT/repos/$REPO/releases/tags/$VERSION | jq "$PARSER"`
+ASSET_ID=`gh_curl $RELASE_URL | jq "$PARSER"`
 if [ "$ASSET_ID" = "null" ]; then
   errcho "ERROR: version not found $VERSION"
   exit 1

--- a/gh-dl-release
+++ b/gh-dl-release
@@ -1,0 +1,40 @@
+#!/usr/bin/env ash
+# Based on original work at https://gist.github.com/maxim/6e15aa45ba010ab030c4
+#
+# USAGE
+# gh-dl-release <github token> <org/repo> <filename> <version or 'latest'>
+
+if [ $# -lt 4 ] ;then
+    echo "Usage: <github token> <org/repo> <filename> <version or 'latest'> <target_dir>"
+    exit 1
+fi
+
+TOKEN="$1"
+REPO="$2"
+FILE="$3"      # the name of your release asset file, e.g. build.tar.gz
+VERSION=$4                       # tag name or the word "latest"
+DIR="$5"  # target directory
+GITHUB_API_ENDPOINT="api.github.com"
+
+alias errcho='>&2 echo'
+
+function gh_curl() {
+  curl -sL -H "Authorization: token $TOKEN" \
+       -H "Accept: application/vnd.github.v3.raw" \
+       $@
+}
+
+if [ "$VERSION" = "latest" ]; then
+  # Github should return the latest release first.
+  PARSER=".[0].assets | map(select(.name == \"$FILE\"))[0].id"
+else
+  PARSER=". | map(select(.tag_name == \"$VERSION\"))[0].assets | map(select(.name == \"$FILE\"))[0].id"
+fi
+
+ASSET_ID=`gh_curl https://$GITHUB_API_ENDPOINT/repos/$REPO/releases | jq "$PARSER"`
+if [ "$ASSET_ID" = "null" ]; then
+  errcho "ERROR: version not found $VERSION"
+  exit 1
+fi
+
+curl -sL --header "Authorization: token $TOKEN" --header 'Accept: application/octet-stream' https://$TOKEN:@$GITHUB_API_ENDPOINT/repos/$REPO/releases/assets/$ASSET_ID > $DIR/$FILE

--- a/gh-dl-release
+++ b/gh-dl-release
@@ -49,7 +49,7 @@ PARSER=".assets | map(select(.name == \"$FILE\"))[0].id"
 
 ASSET_ID=`gh_curl $RELEASE_URL | jq "$PARSER"`
 if [ "$ASSET_ID" = "null" ]; then
-  errcho "ERROR: version not found $VERSION"
+  errcho "ERROR: file not found '$FILE'"
   exit 1
 fi
 

--- a/gh-dl-release
+++ b/gh-dl-release
@@ -40,14 +40,14 @@ gh_get_asset() {
 }
 
 if [ "$VERSION" = "latest" ]; then
-  RELASE_URL="https://$GITHUB_API_ENDPOINT/repos/$REPO/releases/latest"
+  RELEASE_URL="https://$GITHUB_API_ENDPOINT/repos/$REPO/releases/latest"
 else
-  RELASE_URL="https://$GITHUB_API_ENDPOINT/repos/$REPO/releases/tags/$VERSION"
+  RELEASE_URL="https://$GITHUB_API_ENDPOINT/repos/$REPO/releases/tags/$VERSION"
 fi
 
 PARSER=".assets | map(select(.name == \"$FILE\"))[0].id"
 
-ASSET_ID=`gh_curl $RELASE_URL | jq "$PARSER"`
+ASSET_ID=`gh_curl $RELEASE_URL | jq "$PARSER"`
 if [ "$ASSET_ID" = "null" ]; then
   errcho "ERROR: version not found $VERSION"
   exit 1

--- a/gh-dl-release
+++ b/gh-dl-release
@@ -1,40 +1,56 @@
-#!/usr/bin/env ash
+#!/bin/sh
 # Based on original work at https://gist.github.com/maxim/6e15aa45ba010ab030c4
 #
 # USAGE
-# gh-dl-release <github token> <org/repo> <filename> <version or 'latest'>
+# gh-dl-release <org/repo> <version or 'latest'> <filename> [<github token>]
 
-if [ $# -lt 4 ] ;then
-    echo "Usage: <github token> <org/repo> <filename> <version or 'latest'> <target_dir>"
+set -e
+
+if [ $# -lt 3 ] ;then
+    echo "Usage: <org/repo> <version or 'latest'> <filename> [<github token>]"
     exit 1
 fi
 
-TOKEN="$1"
-REPO="$2"
+REPO="$1"
+VERSION="$2"                       # tag name or the word "latest"
 FILE="$3"      # the name of your release asset file, e.g. build.tar.gz
-VERSION=$4                       # tag name or the word "latest"
-DIR="$5"  # target directory
+TOKEN="$4"
 GITHUB_API_ENDPOINT="api.github.com"
 
 alias errcho='>&2 echo'
 
-function gh_curl() {
-  curl -sL -H "Authorization: token $TOKEN" \
+gh_curl() {
+  if [ -z "$TOKEN" ]; then
+    curl -sL \
        -H "Accept: application/vnd.github.v3.raw" \
-       $@
+       "$@"
+  else
+    curl -sL -H "Authorization: token $TOKEN" \
+       -H "Accept: application/vnd.github.v3.raw" \
+       "$@"
+  fi
+}
+
+gh_get_asset() {
+  if [ -z "$TOKEN" ]; then
+    curl -sL -H 'Accept: application/octet-stream' https://$GITHUB_API_ENDPOINT/repos/$REPO/releases/assets/$1
+  else
+    curl -sL -H "Authorization: token $TOKEN" -H 'Accept: application/octet-stream' https://$GITHUB_API_ENDPOINT/repos/$REPO/releases/assets/$1
+  fi
 }
 
 if [ "$VERSION" = "latest" ]; then
-  # Github should return the latest release first.
-  PARSER=".[0].assets | map(select(.name == \"$FILE\"))[0].id"
+  RELASE_URL="https://$GITHUB_API_ENDPOINT/repos/$REPO/releases/latest"
 else
-  PARSER=". | map(select(.tag_name == \"$VERSION\"))[0].assets | map(select(.name == \"$FILE\"))[0].id"
+  RELASE_URL="https://$GITHUB_API_ENDPOINT/repos/$REPO/releases/tags/$VERSION"
 fi
 
-ASSET_ID=`gh_curl https://$GITHUB_API_ENDPOINT/repos/$REPO/releases | jq "$PARSER"`
+PARSER=".assets | map(select(.name == \"$FILE\"))[0].id"
+
+ASSET_ID=`gh_curl https://$GITHUB_API_ENDPOINT/repos/$REPO/releases/tags/$VERSION | jq "$PARSER"`
 if [ "$ASSET_ID" = "null" ]; then
   errcho "ERROR: version not found $VERSION"
   exit 1
 fi
 
-curl -sL --header "Authorization: token $TOKEN" --header 'Accept: application/octet-stream' https://$TOKEN:@$GITHUB_API_ENDPOINT/repos/$REPO/releases/assets/$ASSET_ID > $DIR/$FILE
+gh_get_asset $ASSET_ID > "$FILE"


### PR DESCRIPTION
This allows download from private repos, by using GitHub API.
I added an explicit `private` input flag to instruct the action to use the GitHub API method.

In future releases we can be smart enough to try this method if we get a 404 from the private wget, or even always use the API, as it works for both public and private assets.